### PR TITLE
Build on Debian Wheezy

### DIFF
--- a/benchmark/src/walltime.cc
+++ b/benchmark/src/walltime.cc
@@ -65,9 +65,15 @@ public:
   static WallTimeImp& GetWallTimeImp() {
     static WallTimeImp imp;
 #if __cplusplus >= 201103L
-    static_assert(std::is_trivially_destructible<WallTimeImp>::value,
-                  "WallTimeImp must be trivially destructible to prevent "
-                  "issues with static destruction");
+#if defined(__GNUC__) && (__GNUC__*100 + __GNUC__MINOR__ < 408)
+	static_assert(std::has_trivial_destructor<WallTimeImp>::value,
+	              "WallTimeImp must be trivially destructible to prevent "
+	              "issues with static destruction");
+#else 
+	static_assert(std::is_trivially_destructible<WallTimeImp>::value,
+	              "WallTimeImp must be trivially destructible to prevent "
+				  "issues with static destruction");
+#endif 				  
 #endif
     return imp;
   }

--- a/cpp-netlib/CMakeLists.txt
+++ b/cpp-netlib/CMakeLists.txt
@@ -61,7 +61,7 @@ if (OPENSSL_FOUND)
 endif()
 
 if (${CMAKE_CXX_COMPILER_ID} MATCHES GNU)
-  set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall")
+  set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -std=c++11")
 elseif (${CMAKE_CXX_COMPILER_ID} MATCHES Clang)
   if (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
     # We want to link in C++11 mode if we're using Clang and on OS X.


### PR DESCRIPTION
Refs https://github.com/facebook/osquery/issues/320

Debian Wheezy comes with GCC 4.7.2 and its libstdc++ ( i think, not a big c++ buff :))  does not have is_trivially_destructible, that only exists for gcc 4.8.0. Use has_trivial_destructor for older versions instead.
