### PR TITLE
Add the `logfile_mode` flag

### DIFF
--- a/glog/src/glog/logging.h.in
+++ b/glog/src/glog/logging.h.in
@@ -347,6 +347,9 @@ DECLARE_int32(minloglevel);
 // default logging directory.
 DECLARE_string(log_dir);
 
+// Set the log file mode.
+DECLARE_int32(logfile_mode);
+
 // Sets the path of the directory into which to put additional links
 // to the log files.
 DECLARE_string(log_link);

--- a/glog/src/logging.cc
+++ b/glog/src/logging.cc
@@ -161,6 +161,8 @@ static const char* DefaultLogDir() {
   return "";
 }
 
+GLOG_DEFINE_int32(logfile_mode, 0600, "Log file mode/permissions.");
+
 GLOG_DEFINE_string(log_dir, DefaultLogDir(),
                    "If specified, logfiles are written into this directory instead "
                    "of the default logging directory.");
@@ -897,7 +899,7 @@ bool LogFileObject::CreateLogfile(const string& time_pid_string) {
                            time_pid_string;
   const char* filename = string_filename.c_str();
   // osquery Issue #907, multiple instances writing to the same file.
-  int fd = open(filename, O_WRONLY | O_CREAT, 0600);
+  int fd = open(filename, O_WRONLY | O_CREAT, FLAGS_logfile_mode);
   if (fd == -1) return false;
 #ifdef HAVE_FCNTL
   // Mark the file close-on-exec. We don't really care if this fails


### PR DESCRIPTION
Note: this was originally added to glog in google/glog#26.  I've reused
the original commit, except solving the merge conflict and ensuring that
the default logfile mode does not change (the original patch would have
changed it from 0600 to 0644 - I've restored the 0600 default).
