### PR TITLE
Preparing sqlite3 for static build

### DIFF
--- a/sqlite3/CMakeLists.txt
+++ b/sqlite3/CMakeLists.txt
@@ -17,7 +17,15 @@ add_definitions(
   -DSQLITE_ENABLE_DBSTAT_VTAB
 )
 
-if(NOT WIN32)
+if(WIN32)
+  foreach(flag_var
+          CMAKE_C_FLAGS CMAKE_C_FLAGS_DEBUG CMAKE_C_FLAGS_RELEASE
+          CMAKE_C_FLAGS_MINSIZEREL CMAKE_C_FLAGS_RELWITHDEBINFO)
+    if(${flag_var} MATCHES "/MD")
+      string(REGEX REPLACE "/MD" "/MT" ${flag_var} "${${flag_var}}")
+    endif(${flag_var} MATCHES "/MD")
+  endforeach(flag_var)
+else()
   add_compile_options(
     -Wno-parentheses-equality
     -Wno-unused-value


### PR DESCRIPTION
Modifies the CMake config to build `/MT` sqlite3
